### PR TITLE
Transfert de l'UUID de l'entity sur la classe Book

### DIFF
--- a/flairsou_api/models/book.py
+++ b/flairsou_api/models/book.py
@@ -13,29 +13,34 @@ class Book(TimeStampedModel):
     name : CharField
         Champ de texte qui enregistre le nom du livre.
 
-    entity : ForeignKey
-        Clé étrangère vers l'entité qui possède le livre.
+    entity : UUID
+        Dans la configuration BDE-UTC, entity correspond à l'UUID de
+        l'entité qui possède le livre
 
-    Le couple (name, entity) est unique dans la table : une entité ne peut pas avoir
-    plusieurs livres du même nom.
+    use_equity : BooleanField
+        Champ booléen qui indique si le livre est autorisé à utiliser les
+        comptes de capitaux propres directement ou non (pour la configuration
+        BDE-UTC).
+
+    Le couple (name, entity) est unique dans la table : une entité ne peut pas
+    avoir plusieurs livres du même nom.
     """
     name = models.CharField("Book name",
                             max_length=64,
                             blank=False,
                             null=False)
-    entity = models.ForeignKey('Entity',
-                               on_delete=models.CASCADE,
-                               blank=False,
-                               null=False)
+    entity = models.UUIDField("Entity", blank=False, null=False)
+    use_equity = models.BooleanField("Use Equity Accounts", default=False)
 
     def __str__(self):
         return "{}-{}".format(self.entity, self.name)
 
     class Meta:
         constraints = []
-        # définition de la clé privée comme une contrainte d'unicité sur deux champs
-        # (Django ne peut pas gérer des clés privées sur plusieurs colonnes)
+        # définition de la clé privée comme une contrainte d'unicité sur deux
+        # champs (Django ne peut pas gérer des clés privées sur plusieurs
+        # colonnes)
         constraints.append(
             models.UniqueConstraint(
                 fields=['name', 'entity'],
-                name="%(app_label)s_%(class)s_unique_name_in_enity"))
+                name="%(app_label)s_%(class)s_unique_name_in_entity"))

--- a/flairsou_api/models/entity.py
+++ b/flairsou_api/models/entity.py
@@ -10,19 +10,19 @@ class Entity(TimeStampedModel):
     Attributes
     ----------
     uuid : PositiveIntegerField
-        Champ entier servant à lier l'entité avec une autre base de données (LDAP par exemple).
-        Clé primaire de la relation.
+        Champ entier servant à lier l'entité avec une autre base de données
+        (LDAP par exemple). Clé primaire de la relation.
 
     name : CharField
         Champ de texte qui enregistre le nom de l'entité. Unique dans la table
 
     use_equity : BooleanField
-        Champ booléen qui indique si l'entité est autorisée à utiliser les comptes de capitaux
-        propres directement ou non.
+        Champ booléen qui indique si l'entité est autorisée à utiliser les
+        comptes de capitaux propres directement ou non.
 
     parent : ForeignKey
-        Clé étrangère vers une autre instance de Entity, qui représente l'entité parente
-        de l'entité courante
+        Clé étrangère vers une autre instance de Entity, qui représente
+        l'entité parente de l'entité courante
     """
     uuid = models.UUIDField("uuid", primary_key=True, editable=False)
     name = models.CharField("Entity name", max_length=64)

--- a/flairsou_api/tests/account.py
+++ b/flairsou_api/tests/account.py
@@ -1,13 +1,12 @@
 from django.test import TestCase
 from django.db.utils import IntegrityError
 
-from flairsou_api.models import Account, Book, Entity
+from flairsou_api.models import Account, Book
 
 
 class AccountTestCase(TestCase):
     def setUp(self):
-        BDE = Entity.objects.create(name="BDE-UTC", uuid=1)
-        bookBDE = Book.objects.create(name="Comptes", entity=BDE)
+        bookBDE = Book.objects.create(name="Comptes", entity=1)
         self.assets = Account.objects.create(
             name="Actifs", accountType=Account.AccountType.ASSET, book=bookBDE)
 
@@ -16,7 +15,8 @@ class AccountTestCase(TestCase):
         # ceci doit fonctionner
         accountSG = Account.objects.create(name="SG", parent=self.assets)
 
-        # on vérifie qu'on ne peut pas créer de compte de dépenses sous le compte accountSG
+        # on vérifie qu'on ne peut pas créer de compte de dépenses sous le
+        # compte accountSG
         with self.assertRaises(IntegrityError):
             Account.objects.create(name="Pizzas",
                                    parent=accountSG,

--- a/flairsou_api/tests/unique_constraints.py
+++ b/flairsou_api/tests/unique_constraints.py
@@ -1,15 +1,15 @@
 from django.test import TestCase
 from django.db.utils import IntegrityError
 from django.db import transaction
-from flairsou_api.models import Entity, Book, Account, Transaction, Operation, Reconciliation
+from flairsou_api.models import Entity, Book, Account, Transaction, \
+        Operation, Reconciliation
 import datetime
 
 
 # fonction de test pour les différentes contraintes de base de données
 class UniqueConstraintsTestCase(TestCase):
     def setUp(self):
-        self.BDE = Entity.objects.create(name="BDE-UTC", uuid=1)
-        self.bdeBook = Book.objects.create(name="Comptes", entity=self.BDE)
+        self.bdeBook = Book.objects.create(name="Comptes", entity=1)
         self.assetAccount = Account.objects.create(
             name="Actifs",
             book=self.bdeBook,
@@ -23,7 +23,7 @@ class UniqueConstraintsTestCase(TestCase):
     def test_unique_constraints_book(self):
         # teste la double création d'un livre pour le BDE avec le même nom
         with self.assertRaises(IntegrityError):
-            Book.objects.create(name="Comptes", entity=self.BDE)
+            Book.objects.create(name="Comptes", entity=1)
 
     def test_unique_constraints_account(self):
         # teste la création d'un compte avec un livre ET un parent
@@ -45,7 +45,8 @@ class UniqueConstraintsTestCase(TestCase):
         transactionObj = Transaction.objects.create(
             date=datetime.date(2021, 5, 1))
 
-        # on crée une opération avec deux montants non nuls, ça ne doit pas marcher
+        # on crée une opération avec deux montants non nuls, ça ne doit pas
+        # marcher
         with self.assertRaises(IntegrityError):
             with transaction.atomic():
                 Operation.objects.create(credit=10,


### PR DESCRIPTION
Comme on en a discuté, pour une exploitation au niveau du BDE, j'ai transféré l'UUID de l'entité directement au niveau du book, avec le flag `use_equity`. Dans l'idéal il faudrait gérer une configuration propre mais de toutes façons on va pas le tester, donc bon je me dis qu'on peut déjà commencer par faire un truc qui fonctionne pour notre structure et voir pour l'étendre après.