### PR TITLE
Fix/url filter for accounts

### DIFF
--- a/flairsou_api/tests/account.py
+++ b/flairsou_api/tests/account.py
@@ -292,8 +292,9 @@ class AccountFilterAPITestCase(APITestCase):
 
     def test_filter_by_book(self):
         # on récupère les comptes liés au book 1
-        url = reverse('flairsou_api:account-list')
-        response = self.client.get(url + "?book=1", format='json')
+        url = reverse('flairsou_api:account-list-filter', kwargs={'book': 1})
+        response = self.client.get(url, format='json')
         self.assertEqual(len(response.data), 4)
-        response = self.client.get(url + "?book=2", format='json')
+        url = reverse('flairsou_api:account-list-filter', kwargs={'book': 2})
+        response = self.client.get(url, format='json')
         self.assertEqual(len(response.data), 3)

--- a/flairsou_api/urls.py
+++ b/flairsou_api/urls.py
@@ -1,12 +1,13 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from . import views
 
 app_name = 'flairsou_api'
 urlpatterns = [
-    re_path(r'accounts/(?P<book>\d+)?$',
-            views.AccountList.as_view(),
-            name="account-list"),
+    path('accounts/', views.AccountList.as_view(), name="account-list"),
+    path('accounts/byBook/<int:book>/',
+         views.AccountList.as_view(),
+         name="account-list-filter"),
     path('accounts/<int:pk>/',
          views.AccountDetail.as_view(),
          name="account-detail"),

--- a/flairsou_api/views/account_views.py
+++ b/flairsou_api/views/account_views.py
@@ -21,7 +21,7 @@ class AccountList(mixins.ListModelMixin, mixins.CreateModelMixin,
         """
         queryset = fm.Account.objects.all()
 
-        book_pk = self.request.query_params.get('book')
+        book_pk = self.kwargs.get('book')
         if book_pk is not None:
             queryset = queryset.filter(book__pk=book_pk)
 


### PR DESCRIPTION
Changement du filtrage des comptes par livre : utilisation d'une route complète `accounts/byBook/<int:book>/` plutôt qu'une expression régulière pour avoir le filtre automatique, comme fait pour le filtrage des livres par entités dans #32.