### PR TITLE
Dev/split classes get post

### DIFF
--- a/flairsou_api/tests/account.py
+++ b/flairsou_api/tests/account.py
@@ -34,7 +34,7 @@ class AccountAPITestCase(APITestCase):
         nbAccounts = Account.objects.count()
 
         # on crée un compte sans book : l'API refuse
-        url = reverse('flairsou_api:account-list')
+        url = reverse('flairsou_api:account-create')
         data = {
             "name": "SG",
             "account_type": Account.AccountType.ASSET,
@@ -50,7 +50,7 @@ class AccountAPITestCase(APITestCase):
         nbAccounts = Account.objects.count()
 
         # on crée un sous-compte avec le mauvais type : l'API refuse
-        url = reverse('flairsou_api:account-list')
+        url = reverse('flairsou_api:account-create')
         data = {
             "name": "SG",
             "account_type": Account.AccountType.ASSET,  # sous-compte ASSET
@@ -66,7 +66,7 @@ class AccountAPITestCase(APITestCase):
         nbAccounts = Account.objects.count()
 
         # on crée un nouveau compte rattaché au book principal
-        url = reverse('flairsou_api:account-list')
+        url = reverse('flairsou_api:account-create')
         data = {
             "name": "Recettes",
             "account_type": Account.AccountType.INCOME,
@@ -145,7 +145,7 @@ class AccountAPITestCase(APITestCase):
     def test_change_parent(self):
         # on teste le changement de parent
         # on crée un nouveau sous-compte
-        url = reverse('flairsou_api:account-list')
+        url = reverse('flairsou_api:account-create')
         data = {
             "name": "Pizzas",
             "account_type": Account.AccountType.EXPENSE,
@@ -242,9 +242,15 @@ class AccountAPITestCase(APITestCase):
             "parent": self.liabilities.pk,
             "book": self.book.pk
         }
-        url = reverse('flairsou_api:account-list')
+        url = reverse('flairsou_api:account-create')
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_get_forbidden_on_create(self):
+        url = reverse('flairsou_api:account-create')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code,
+                         status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
 class AccountFilterAPITestCase(APITestCase):
@@ -292,9 +298,11 @@ class AccountFilterAPITestCase(APITestCase):
 
     def test_filter_by_book(self):
         # on récupère les comptes liés au book 1
-        url = reverse('flairsou_api:account-list-filter', kwargs={'book': 1})
+        url = reverse('flairsou_api:account-filter-by-book',
+                      kwargs={'book': 1})
         response = self.client.get(url, format='json')
         self.assertEqual(len(response.data), 4)
-        url = reverse('flairsou_api:account-list-filter', kwargs={'book': 2})
+        url = reverse('flairsou_api:account-filter-by-book',
+                      kwargs={'book': 2})
         response = self.client.get(url, format='json')
         self.assertEqual(len(response.data), 3)

--- a/flairsou_api/tests/book.py
+++ b/flairsou_api/tests/book.py
@@ -11,13 +11,14 @@ class BookAPITestCase(APITestCase):
         self.book = Book.objects.create(name="Comptes BDE",
                                         entity=uuid.UUID(int=1))
 
-    def test_get_all_books(self):
+    def test_get_forbidden_on_create(self):
         """
-        Vérifie que la route globale fonctionne
+        Vérifie qu'on ne peut pas faire de requête GET sur la route de création
         """
-        url = reverse('flairsou_api:book-list')
+        url = reverse('flairsou_api:book-create')
         response = self.client.get(url, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code,
+                         status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def test_filter_book_by_pk(self):
         """
@@ -35,7 +36,7 @@ class BookAPITestCase(APITestCase):
         """
         Vérifie que le filtrage des livres par entité fonctionne
         """
-        url = reverse('flairsou_api:book-list-filter',
+        url = reverse('flairsou_api:book-filter-by-entity',
                       kwargs={'uuid': self.book.entity})
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/flairsou_api/tests/book.py
+++ b/flairsou_api/tests/book.py
@@ -37,7 +37,7 @@ class BookAPITestCase(APITestCase):
         Vérifie que le filtrage des livres par entité fonctionne
         """
         url = reverse('flairsou_api:book-filter-by-entity',
-                      kwargs={'uuid': self.book.entity})
+                      kwargs={'entity': self.book.entity})
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)

--- a/flairsou_api/urls.py
+++ b/flairsou_api/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
     # sur books/ on a uniquement la création des livres
     path('books/', views.BookCreation.as_view(), name="book-create"),
     # on a ensuite les routes de listing par filtre
-    path('books/byEntity/<uuid:uuid>/',
+    path('books/byEntity/<uuid:entity>/',
          views.BookListFilter.as_view(),
          name="book-filter-by-entity"),
     # et la route de détails sur un livre particulier

--- a/flairsou_api/urls.py
+++ b/flairsou_api/urls.py
@@ -14,9 +14,12 @@ urlpatterns = [
     path('accounts/<int:pk>/',
          views.AccountDetail.as_view(),
          name="account-detail"),
-    path('books/', views.BookList.as_view(), name="book-list"),
+    # sur books/ on a uniquement la création des livres
+    path('books/', views.BookCreation.as_view(), name="book-create"),
+    # on a ensuite les routes de listing par filtre
     path('books/byEntity/<uuid:uuid>/',
-         views.BookList.as_view(),
-         name="book-list-filter"),
+         views.BookListFilter.as_view(),
+         name="book-filter-by-entity"),
+    # et la route de détails sur un livre particulier
     path('books/<int:pk>/', views.BookDetail.as_view(), name="book-detail"),
 ]

--- a/flairsou_api/urls.py
+++ b/flairsou_api/urls.py
@@ -4,10 +4,13 @@ from . import views
 
 app_name = 'flairsou_api'
 urlpatterns = [
-    path('accounts/', views.AccountList.as_view(), name="account-list"),
+    # sur accounts/ on a uniquement la création des comptes
+    path('accounts/', views.AccountCreation.as_view(), name="account-create"),
+    # on a ensuite les routes de listing par filtre
     path('accounts/byBook/<int:book>/',
-         views.AccountList.as_view(),
-         name="account-list-filter"),
+         views.AccountListFilter.as_view(),
+         name="account-filter-by-book"),
+    # et la route de détails d'un compte particulier
     path('accounts/<int:pk>/',
          views.AccountDetail.as_view(),
          name="account-detail"),

--- a/flairsou_api/views/__init__.py
+++ b/flairsou_api/views/__init__.py
@@ -1,10 +1,11 @@
 from .account_views import AccountDetail, AccountCreation, AccountListFilter
-from .book_views import BookDetail, BookList
+from .book_views import BookDetail, BookCreation, BookListFilter
 
 __all__ = [
     AccountDetail,
     AccountListFilter,
     AccountCreation,
     BookDetail,
-    BookList,
+    BookListFilter,
+    BookCreation,
 ]

--- a/flairsou_api/views/__init__.py
+++ b/flairsou_api/views/__init__.py
@@ -1,9 +1,10 @@
-from .account_views import AccountDetail, AccountList
+from .account_views import AccountDetail, AccountCreation, AccountListFilter
 from .book_views import BookDetail, BookList
 
 __all__ = [
     AccountDetail,
-    AccountList,
+    AccountListFilter,
+    AccountCreation,
     BookDetail,
     BookList,
 ]

--- a/flairsou_api/views/account_views.py
+++ b/flairsou_api/views/account_views.py
@@ -13,7 +13,17 @@ class AccountCreation(mixins.CreateModelMixin, generics.GenericAPIView):
 
     def post(self, request, *args, **kwargs):
         """
-        Crée un nouveau compte
+        Crée un nouveau compte avec les attributs suivants :
+        - "name" : nom du compte
+        - "account_type" : type du compte
+            - 0 : Actif
+            - 1 : Passif
+            - 2 : Revenus
+            - 3 : Dépenses
+            - 4 : Capitaux Propres
+        - "virtual" : booléen indiquant si le compte est virtuel ou non
+        - "parent" : clé primaire du compte parent, peut être null
+        - "book" : clé primaire du livre associé, obligatoire
         """
         return self.create(request, *args, **kwargs)
 
@@ -40,7 +50,9 @@ class AccountListFilter(mixins.ListModelMixin, generics.GenericAPIView):
 
     def get(self, request, *args, **kwargs):
         """
-        Renvoie la liste des comptes en fonction du filtre utilisé
+        Renvoie la liste des comptes en fonction du filtre utilisé.
+        Filtrages possibles :
+        - par livre : {book} => clé primaire du livre à utiliser en filtre
         """
         return self.list(request, *args, **kwargs)
 
@@ -56,18 +68,21 @@ class AccountDetail(mixins.RetrieveModelMixin, mixins.UpdateModelMixin,
 
     def get(self, request, *args, **kwargs):
         """
-        Sur une requête GET, renvoie la liste des comptes
+        Renvoie le détail du compte passé en paramètre
+        - id : clé primaire du compte à récupérer
         """
         return self.retrieve(request, *args, **kwargs)
 
     def put(self, request, *args, **kwargs):
         """
-        Sur une requee PUT, met à jour le compte
+        Met à jour le compte passé en paramètre
+        - id : clé primaire du compte à mettre à jour
         """
         return self.update(request, *args, **kwargs)
 
     def delete(self, request, *args, **kwargs):
         """
-        Sur une requête DELETE, supprime le compte
+        Supprime le compte passé en paramètre
+        - id : clé primaire du compte à supprimer
         """
         return self.destroy(request, *args, **kwargs)

--- a/flairsou_api/views/account_views.py
+++ b/flairsou_api/views/account_views.py
@@ -5,11 +5,22 @@ import flairsou_api.models as fm
 import flairsou_api.serializers as fs
 
 
-class AccountList(mixins.ListModelMixin, mixins.CreateModelMixin,
-                  generics.GenericAPIView):
+class AccountCreation(mixins.CreateModelMixin, generics.GenericAPIView):
     """
-    Vue qui fournit la liste des comptes créés et qui permet de créer un
-    nouveau compte dans la base.
+    Vue qui qui permet de créer un nouveau compte dans la base.
+    """
+    serializer_class = fs.AccountSerializer
+
+    def post(self, request, *args, **kwargs):
+        """
+        Crée un nouveau compte
+        """
+        return self.create(request, *args, **kwargs)
+
+
+class AccountListFilter(mixins.ListModelMixin, generics.GenericAPIView):
+    """
+    Vue qui permet de récupérer une liste de comptes par rapport à un filtrage
     """
     serializer_class = fs.AccountSerializer
 
@@ -29,15 +40,9 @@ class AccountList(mixins.ListModelMixin, mixins.CreateModelMixin,
 
     def get(self, request, *args, **kwargs):
         """
-        Sur une requête GET, renvoie la liste de tous les comptes
+        Renvoie la liste des comptes en fonction du filtre utilisé
         """
         return self.list(request, *args, **kwargs)
-
-    def post(self, request, *args, **kwargs):
-        """
-        Sur une requête POST, crée un nouveau compte
-        """
-        return self.create(request, *args, **kwargs)
 
 
 class AccountDetail(mixins.RetrieveModelMixin, mixins.UpdateModelMixin,

--- a/flairsou_api/views/book_views.py
+++ b/flairsou_api/views/book_views.py
@@ -5,11 +5,22 @@ import flairsou_api.models as fm
 import flairsou_api.serializers as fs
 
 
-class BookList(mixins.ListModelMixin, mixins.CreateModelMixin,
-               generics.GenericAPIView):
+class BookCreation(mixins.CreateModelMixin, generics.GenericAPIView):
     """
-    Vue qui fournit la liste des livres créés et qui permet de créer un
-    nouveau livre dans la base.
+    Vue permettant la création d'un nouveau livre de comptes
+    """
+    serializer_class = fs.BookSerializer
+
+    def post(self, request, *args, **kwargs):
+        """
+        Création d'un nouveau livre
+        """
+        return self.create(request, *args, **kwargs)
+
+
+class BookListFilter(mixins.ListModelMixin, generics.GenericAPIView):
+    """
+    Vue qui fournit une liste de livres à partir d'un certain filtre
     """
     serializer_class = fs.BookSerializer
 
@@ -32,12 +43,6 @@ class BookList(mixins.ListModelMixin, mixins.CreateModelMixin,
         Sur une requête GET, renvoie la liste de tous les livres
         """
         return self.list(request, *args, **kwargs)
-
-    def post(self, request, *args, **kwargs):
-        """
-        Sur une requête POST, crée un nouveau livre
-        """
-        return self.create(request, *args, **kwargs)
 
 
 class BookDetail(mixins.RetrieveModelMixin, mixins.UpdateModelMixin,

--- a/flairsou_api/views/book_views.py
+++ b/flairsou_api/views/book_views.py
@@ -13,7 +13,9 @@ class BookCreation(mixins.CreateModelMixin, generics.GenericAPIView):
 
     def post(self, request, *args, **kwargs):
         """
-        Création d'un nouveau livre
+        Crée un nouveau livre avec les paramètres suivants :
+        - "name" : nom du livre à créer
+        - "entity" : UUID correspondant à l'entité possédant le livre
         """
         return self.create(request, *args, **kwargs)
 
@@ -28,7 +30,7 @@ class BookListFilter(mixins.ListModelMixin, generics.GenericAPIView):
         """
         Adapte la queryset en fonction de la requête qui a été passée.
         Les filtres possibles sont :
-        - entity : uuid de l'entité associée aux livres à retourner
+        - entity : UUID de l'entité associée aux livres à retourner
         """
         queryset = fm.Book.objects.all()
 
@@ -40,7 +42,9 @@ class BookListFilter(mixins.ListModelMixin, generics.GenericAPIView):
 
     def get(self, request, *args, **kwargs):
         """
-        Sur une requête GET, renvoie la liste de tous les livres
+        Renvoie la liste des livres en fonction du filtre utilisé.
+        Filtrages possibles :
+        - par entité : {uuid} => UUID de l'entité utilisée pour le filtre
         """
         return self.list(request, *args, **kwargs)
 
@@ -56,18 +60,24 @@ class BookDetail(mixins.RetrieveModelMixin, mixins.UpdateModelMixin,
 
     def get(self, request, *args, **kwargs):
         """
-        Sur une requête GET, renvoie le détail du livre
+        Renvoie le détail du livre passé en paramètre
+        - id : clé primaire du livre à récupérer
         """
         return self.retrieve(request, *args, **kwargs)
 
     def put(self, request, *args, **kwargs):
         """
-        Sur une requete PUT, met à jour le livre
+        Met à jour le livre passé en paramètre
+        - id : clé primaire du livre à modifier
         """
         return self.update(request, *args, **kwargs)
 
     def delete(self, request, *args, **kwargs):
         """
-        Sur une requête DELETE, supprime le livre
+        Supprime le livre passé en paramètre
+        - id : clé primaire du livre à supprimer
+
+        Attention : cette opération supprime tous les comptes associés à
+        ce livre, et toutes les transactions associées à ces comptes !
         """
         return self.destroy(request, *args, **kwargs)

--- a/flairsou_api/views/book_views.py
+++ b/flairsou_api/views/book_views.py
@@ -34,7 +34,7 @@ class BookListFilter(mixins.ListModelMixin, generics.GenericAPIView):
         """
         queryset = fm.Book.objects.all()
 
-        entity = self.kwargs.get('uuid')
+        entity = self.kwargs.get('entity')
         if entity is not None:
             queryset = queryset.filter(entity=entity)
 
@@ -44,7 +44,7 @@ class BookListFilter(mixins.ListModelMixin, generics.GenericAPIView):
         """
         Renvoie la liste des livres en fonction du filtre utilisé.
         Filtrages possibles :
-        - par entité : {uuid} => UUID de l'entité utilisée pour le filtre
+        - par entité : {entity} => UUID de l'entité utilisée pour le filtre
         """
         return self.list(request, *args, **kwargs)
 


### PR DESCRIPTION
Séparation des classes de vues pour avoir : 
- une classe dédiée à la création des objets sur la route de base (`accounts/`, `books/`...)
- une classe dédiée au listing avec différents filtres possibles, chaque filtre devant être commenté dans cette classe pour apparaître dans la doc (`accounts/byBook/{book}/`, `book/byEntity/{entity}/`...)
- une classe dédiée au détail d'une instance particulière (`accounts/{account}/`...)

Les buts étant : 
1. de pouvoir documenter séparément la route de création et les routes de récupération filtrée
2. de faire disparaître les routes de récupération globale

Prérequis avant le merge : merger la branche `doc_api` sur main, pour pouvoir la merger dans cette classe et vérifier que la doc donne bien ce qu'on veut.