### PR TITLE
Feature/delete useless api

### DIFF
--- a/flairsou_api/tests/book.py
+++ b/flairsou_api/tests/book.py
@@ -1,42 +1,30 @@
 from rest_framework.test import APITestCase
 from rest_framework import status
 from django.urls import reverse
+from django.db.utils import IntegrityError
 
 from flairsou_api.models import Book, Account
 import uuid
 
 
 class BookAPITestCase(APITestCase):
+
     def setUp(self):
         self.book = Book.objects.create(name="Comptes BDE",
                                         entity=uuid.UUID(int=1))
 
     def test_create_book(self):
         """
-        Vérifie que la création de livre fonctionne
+        Vérifie que la création de livre fonctionne via python, l'API
+        de création de compte est désactivée
         """
-        url = reverse('flairsou_api:book-create')
-        data = {
-            'name': 'BDE-UTC',
-            'entity': '00000000-0000-0000-0000-000000000002'
-        }
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        # première création doit fonctionner
+        Book.objects.create(name="BDE-UTC", entity=uuid.UUID(int=2))
 
         # le deuxième test ne doit pas fonctionner car on crée deux livres pour
         # la même entité
-        data['name'] = 'BDE-UTC-2'
-        response = self.client.post(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_get_forbidden_on_create(self):
-        """
-        Vérifie qu'on ne peut pas faire de requête GET sur la route de création
-        """
-        url = reverse('flairsou_api:book-create')
-        response = self.client.get(url, format='json')
-        self.assertEqual(response.status_code,
-                         status.HTTP_405_METHOD_NOT_ALLOWED)
+        with self.assertRaises(IntegrityError):
+            Book.objects.create(name="BDE-UTC-2", entity=uuid.UUID(int=2))
 
     def test_filter_book_by_pk(self):
         """
@@ -76,6 +64,7 @@ class BookAccountsAPITestCase(APITestCase):
     """
     Classe de test pour le filtrage des comptes par book
     """
+
     def setUp(self):
         book1 = Book.objects.create(name="Comptes", entity=uuid.UUID(int=1))
         Account.objects.create(name="Actifs",

--- a/flairsou_api/urls.py
+++ b/flairsou_api/urls.py
@@ -33,11 +33,7 @@ urlpatterns = [
          name="book-get-all-accounts"),
     # et la route de détails sur un livre particulier
     path('books/<int:pk>/', views.BookDetail.as_view(), name="book-detail"),
-    # urls operations pour le dev, à retirer ensuite
-    path('operations/', views.OperationList.as_view(), name="operation-list"),
-    path('operations/<int:pk>/',
-         views.OperationDetail.as_view(),
-         name="operation-detail"),
+    # routes transactions
     path('transactions/',
          views.TransactionList.as_view(),
          name="transaction-list"),

--- a/flairsou_api/urls.py
+++ b/flairsou_api/urls.py
@@ -21,9 +21,7 @@ urlpatterns = [
     path('accounts/<int:pk>/operations/',
          views.AccountOpsList.as_view(),
          name="account-operation-list"),
-    # sur books/ on a uniquement la création des livres
-    path('books/', views.BookCreation.as_view(), name="book-create"),
-    # on a ensuite les routes de listing par filtre
+    # récupération du livre par l'entité associée
     path('books/byEntity/<uuid:entity>/',
          views.BookListFilter.as_view(),
          name="book-filter-by-entity"),

--- a/flairsou_api/views/__init__.py
+++ b/flairsou_api/views/__init__.py
@@ -1,6 +1,6 @@
 from .account_views import AccountDetail, AccountCreation
 from .account_views import AccountBalance, AccountOpsList
-from .book_views import BookDetail, BookCreation, BookListFilter
+from .book_views import BookDetail, BookListFilter
 from .book_views import BookAccountList
 from .transaction_views import TransactionDetail, TransactionList
 from .reconciliation_views import ReconciliationView
@@ -13,7 +13,6 @@ __all__ = [
     BookAccountList,
     BookDetail,
     BookListFilter,
-    BookCreation,
     TransactionDetail,
     TransactionList,
     ReconciliationView,

--- a/flairsou_api/views/__init__.py
+++ b/flairsou_api/views/__init__.py
@@ -2,7 +2,6 @@ from .account_views import AccountDetail, AccountCreation
 from .account_views import AccountBalance, AccountOpsList
 from .book_views import BookDetail, BookCreation, BookListFilter
 from .book_views import BookAccountList
-from .transaction_views import OperationDetail, OperationList
 from .transaction_views import TransactionDetail, TransactionList
 from .reconciliation_views import ReconciliationView
 
@@ -15,8 +14,6 @@ __all__ = [
     BookDetail,
     BookListFilter,
     BookCreation,
-    OperationDetail,
-    OperationList,
     TransactionDetail,
     TransactionList,
     ReconciliationView,

--- a/flairsou_api/views/book_views.py
+++ b/flairsou_api/views/book_views.py
@@ -5,21 +5,6 @@ import flairsou_api.models as fm
 import flairsou_api.serializers as fs
 
 
-class BookCreation(mixins.CreateModelMixin, generics.GenericAPIView):
-    """
-    Vue permettant la création d'un nouveau livre de comptes
-    """
-    serializer_class = fs.BookSerializer
-
-    def post(self, request, *args, **kwargs):
-        """
-        Crée un nouveau livre avec les paramètres suivants :
-        - "name" : nom du livre à créer
-        - "entity" : UUID correspondant à l'entité possédant le livre
-        """
-        return self.create(request, *args, **kwargs)
-
-
 class BookListFilter(mixins.ListModelMixin, generics.GenericAPIView):
     """
     Vue qui fournit une liste de livres à partir d'un certain filtre
@@ -71,16 +56,6 @@ class BookDetail(mixins.RetrieveModelMixin, mixins.UpdateModelMixin,
         - id : clé primaire du livre à modifier
         """
         return self.update(request, *args, **kwargs)
-
-    def delete(self, request, *args, **kwargs):
-        """
-        Supprime le livre passé en paramètre
-        - id : clé primaire du livre à supprimer
-
-        Attention : cette opération supprime tous les comptes associés à
-        ce livre, et toutes les transactions associées à ces comptes !
-        """
-        return self.destroy(request, *args, **kwargs)
 
 
 class BookAccountList(mixins.RetrieveModelMixin, generics.GenericAPIView):

--- a/flairsou_api/views/transaction_views.py
+++ b/flairsou_api/views/transaction_views.py
@@ -5,66 +5,16 @@ import flairsou_api.models as fm
 import flairsou_api.serializers as fs
 
 
-# les deux classes Operation sont là pour le dev, mais il ne sera probablement
-# pas nécessaire d'avoir une route uniquement pour les opérations, donc on
-# pourra enlever ça plus tard
-class OperationList(mixins.ListModelMixin, generics.GenericAPIView):
+class TransactionList(mixins.CreateModelMixin, generics.GenericAPIView):
     """
-    Vue qui fournit la liste des comptes créés et qui permet de créer un
-    nouveau compte dans la base.
-    """
-    queryset = fm.Operation.objects.all()
-    serializer_class = fs.OperationSerializer
-
-    def get(self, request, *args, **kwargs):
-        """
-        Sur une requête GET, renvoie la liste de toutes les opérations
-        """
-        return self.list(request, *args, **kwargs)
-
-
-class OperationDetail(mixins.RetrieveModelMixin, generics.GenericAPIView):
-    """
-    """
-    queryset = fm.Operation.objects.all()
-    serializer_class = fs.OperationSerializer
-
-    def get(self, request, *args, **kwargs):
-        """
-        Sur une requête GET, renvoie la liste de l'opération demandée
-        """
-        return self.retrieve(request, *args, **kwargs)
-
-
-##############################
-
-
-class TransactionList(mixins.ListModelMixin, mixins.CreateModelMixin,
-                      generics.GenericAPIView):
-    """
-    Vue qui fournit la liste des transactions créés et qui permet de créer
-    une nouvelle transaction.
+    Vue qui permet de créer une nouvelle transaction.
     """
     serializer_class = fs.TransactionSerializer
 
-    def get_queryset(self):
-        queryset = fm.Transaction.objects.all()
-
-        # filtrage par entité
-        # entity est un str représentant un UUID valide
-        entity = self.request.query_params.get('entity')
-        if entity is not None:
-            queryset = fm.Transaction.filter_by_entity(entity)
-
-        return queryset
-
-    def get(self, request, *args, **kwargs):
-        """
-        Sur une requête GET, renvoie la liste de toutes les transactions
-        """
-        return self.list(request, *args, **kwargs)
-
     def post(self, request, *args, **kwargs):
+        """
+        Création d'une nouvelle transaction
+        """
         return self.create(request, *args, **kwargs)
 
 

--- a/flairsou_api/views/transaction_views.py
+++ b/flairsou_api/views/transaction_views.py
@@ -69,7 +69,7 @@ class TransactionList(mixins.ListModelMixin, mixins.CreateModelMixin,
 
 
 class TransactionDetail(mixins.RetrieveModelMixin, mixins.UpdateModelMixin,
-                        generics.GenericAPIView):
+                        mixins.DestroyModelMixin, generics.GenericAPIView):
     """
     Vue qui fournit le détail d'une transaction par son identifiant
     """
@@ -87,3 +87,9 @@ class TransactionDetail(mixins.RetrieveModelMixin, mixins.UpdateModelMixin,
         Sur une requete PUT, met à jour la transaction
         """
         return self.update(request, *args, **kwargs)
+
+    def delete(self, request, *args, **kwargs):
+        """
+        Supprime la transaction
+        """
+        return self.destroy(request, *args, **kwargs)


### PR DESCRIPTION
Suppression des API qui ne doivent normalement pas être utilisées par le projet.

API supprimées : 
- `GET /books/` : les livres sont créés en dehors de l'API à partir d'une fonction qui récupère les infos du PDA
- `DELETE /books/{id}/` : les utilisateurs ne peuvent pas supprimer les livres de compte
- `/operations/*` : les opérations n'ont pas besoin d'être directement récupérées, elles sont récupérées à travers les transactions

Au passage, j'ai ajouté l'API pour supprimer une transaction sur `DELETE /transactions/{id}/` qui n'existait pas.