### PR TITLE
Disable lint linebreak & enable webpack source-map

### DIFF
--- a/flairsou_frontend/.eslintrc.json
+++ b/flairsou_frontend/.eslintrc.json
@@ -20,6 +20,7 @@
     ],
     "rules": {
         "react-hooks/rules-of-hooks": "error", // Vérifie les règles des Hooks
-        "react-hooks/exhaustive-deps": "warn"  // Vérifie les tableaux de dépendances
+        "react-hooks/exhaustive-deps": "warn", // Vérifie les tableaux de dépendances
+        "linebreak-style": "off"
     }
 }

--- a/flairsou_frontend/package.json
+++ b/flairsou_frontend/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "webpack --mode development --watch --entry ./src/index.js --output-path ./static/flairsou_frontend",
+    "dev": "webpack --mode development --watch --devtool=eval-source-map --entry ./src/index.js --output-path ./static/flairsou_frontend",
     "build": "webpack --mode production --entry ./src/index.js --output-path ./static/flairsou_frontend",
-    "build-dev": "webpack --mode development --entry ./src/index.js --output-path ./static/flairsou_frontend",
+    "build-dev": "webpack --mode development --entry --devtool=eval-source-map ./src/index.js --output-path ./static/flairsou_frontend",
     "lint": "eslint src/**/*.js src/**/*.jsx",
     "lint-fix": "eslint src/**/*.js src/**/*.jsx --fix",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Parce que j'en ai marre des alertes eslint de line-break dès que je change de branche, & que les source-maps pour le debug c'est confort.