### PR TITLE
Vérification de la date avec <=

### DIFF
--- a/flairsou_api/models/transaction.py
+++ b/flairsou_api/models/transaction.py
@@ -67,7 +67,7 @@ class Transaction(TimeStampedModel):
             if op.account.reconciliation_set.count() > 0:
                 last_reconc_date = op.account.reconciliation_set.order_by(
                     'date').last().date
-                if self.date < last_reconc_date:
+                if self.date <= last_reconc_date:
                     return True
 
         return False


### PR DESCRIPTION
Sans ça, les transactions du jour du rapprochement sont considérées non rapprochées.