### PR TITLE
Fix erreur de CI (cf doc actions/@checkout et tj-actions/@changed-files)

### DIFF
--- a/.github/workflows/flairsou-ci.yml
+++ b/.github/workflows/flairsou-ci.yml
@@ -22,6 +22,8 @@ jobs:
     name: "Getting changed files"
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2  # récupère 2 commits, nécessaire pour comparer avec le précédent sur un push 
       - name: "Get backend changed files"
         id: changed-backend-files
         uses: tj-actions/changed-files@v16


### PR DESCRIPTION
Visiblement la CI n'est pas capable de récupérer le commit précédent pour faire les tests sur les évènements push, donc j'ai rajouté le checkout de 2 commits (pas de tout l'arbre) pour que ça fonctionne.